### PR TITLE
Stops the clearing of owned (should be pasture) and shiny pokémon :)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "io.github.adainish"
-version = "1.1.1-SNAPSHOT"
+version = "1.1.2-SNAPSHOT"
 
 architectury {
     platformSetupLoomIde()

--- a/src/main/java/io/github/adainish/cobblemonclear/obj/PokemonWiper.java
+++ b/src/main/java/io/github/adainish/cobblemonclear/obj/PokemonWiper.java
@@ -103,7 +103,7 @@ public class PokemonWiper
                             continue;
                         }
                     }
-                    if(!e.isBusy()) {
+                    if(!e.isBusy() && e.getOwnerUUID() == null && !e.getPokemon().getShiny()) {
                         e.discard();
                         wipedCount.getAndIncrement();
                     }


### PR DESCRIPTION
I started to make the entire whitelist spec based instead of a shiny check but don't know how your config works (literally got down to just config, and reverted everything lol) and cba to test